### PR TITLE
Scaffold agentctl command modules

### DIFF
--- a/cli/src/agentctl/config/add.rs
+++ b/cli/src/agentctl/config/add.rs
@@ -1,0 +1,15 @@
+use crate::commands::OutputFormat;
+use clap::Args;
+
+#[derive(Args, Debug)]
+pub struct AddArgs {
+    #[arg(short, long)]
+    pub output: Option<OutputFormat>,
+}
+
+pub fn add(args: &AddArgs) {
+    println!("Adding configuration...");
+    if let Some(fmt) = &args.output {
+        println!("Output format: {:?}", fmt);
+    }
+}

--- a/cli/src/agentctl/config/mod.rs
+++ b/cli/src/agentctl/config/mod.rs
@@ -1,0 +1,12 @@
+pub mod add;
+pub mod show;
+
+use clap::Subcommand;
+
+#[derive(Subcommand, Debug)]
+pub enum ConfigCommands {
+    /// Add a configuration profile
+    Add(add::AddArgs),
+    /// Show current configuration
+    Show(show::ShowArgs),
+}

--- a/cli/src/agentctl/config/show.rs
+++ b/cli/src/agentctl/config/show.rs
@@ -1,0 +1,15 @@
+use crate::commands::OutputFormat;
+use clap::Args;
+
+#[derive(Args, Debug)]
+pub struct ShowArgs {
+    #[arg(short, long)]
+    pub output: Option<OutputFormat>,
+}
+
+pub fn show(args: &ShowArgs) {
+    println!("Current configuration...");
+    if let Some(fmt) = &args.output {
+        println!("Output format: {:?}", fmt);
+    }
+}

--- a/cli/src/agentctl/deploy.rs
+++ b/cli/src/agentctl/deploy.rs
@@ -1,0 +1,17 @@
+use crate::commands::OutputFormat;
+use clap::Args;
+
+#[derive(Args, Debug)]
+pub struct DeployArgs {
+    #[arg(help = "ID of the entity")]
+    pub id: String,
+    #[arg(short, long)]
+    pub output: Option<OutputFormat>,
+}
+
+pub fn deploy(args: &DeployArgs) {
+    println!("Deploying {}", args.id);
+    if let Some(fmt) = &args.output {
+        println!("Output format: {:?}", fmt);
+    }
+}

--- a/cli/src/agentctl/describe.rs
+++ b/cli/src/agentctl/describe.rs
@@ -1,0 +1,17 @@
+use crate::commands::OutputFormat;
+use clap::Args;
+
+#[derive(Args, Debug)]
+pub struct DescribeArgs {
+    #[arg(help = "ID of the entity")] 
+    pub id: String,
+    #[arg(short, long)]
+    pub output: Option<OutputFormat>,
+}
+
+pub fn describe(args: &DescribeArgs) {
+    println!("Describing {}", args.id);
+    if let Some(fmt) = &args.output {
+        println!("Output format: {:?}", fmt);
+    }
+}

--- a/cli/src/agentctl/env/mod.rs
+++ b/cli/src/agentctl/env/mod.rs
@@ -1,0 +1,12 @@
+pub mod show;
+pub mod set;
+
+use clap::Subcommand;
+
+#[derive(Subcommand, Debug)]
+pub enum EnvCommands {
+    /// Show available environment profiles
+    Show(show::ShowArgs),
+    /// Set an environment profile
+    Set(set::SetArgs),
+}

--- a/cli/src/agentctl/env/set.rs
+++ b/cli/src/agentctl/env/set.rs
@@ -1,0 +1,17 @@
+use crate::commands::OutputFormat;
+use clap::Args;
+
+#[derive(Args, Debug)]
+pub struct SetArgs {
+    #[arg(help = "Profile ID")]
+    pub profile_id: String,
+    #[arg(short, long)]
+    pub output: Option<OutputFormat>,
+}
+
+pub fn set(args: &SetArgs) {
+    println!("Setting environment profile to: {}", args.profile_id);
+    if let Some(fmt) = &args.output {
+        println!("Output format: {:?}", fmt);
+    }
+}

--- a/cli/src/agentctl/env/show.rs
+++ b/cli/src/agentctl/env/show.rs
@@ -1,0 +1,15 @@
+use crate::commands::OutputFormat;
+use clap::Args;
+
+#[derive(Args, Debug)]
+pub struct ShowArgs {
+    #[arg(short, long)]
+    pub output: Option<OutputFormat>,
+}
+
+pub fn show(args: &ShowArgs) {
+    println!("Showing environment profiles...");
+    if let Some(fmt) = &args.output {
+        println!("Output format: {:?}", fmt);
+    }
+}

--- a/cli/src/agentctl/invoke.rs
+++ b/cli/src/agentctl/invoke.rs
@@ -1,0 +1,19 @@
+use crate::commands::OutputFormat;
+use clap::Args;
+
+#[derive(Args, Debug)]
+pub struct InvokeArgs {
+    #[arg(help = "ID of the entity")]
+    pub id: String,
+    #[arg(short, long, help = "Input to provide")]
+    pub input: String,
+    #[arg(short, long)]
+    pub output: Option<OutputFormat>,
+}
+
+pub fn invoke(args: &InvokeArgs) {
+    println!("Invoking {} with input {}", args.id, args.input);
+    if let Some(fmt) = &args.output {
+        println!("Output format: {:?}", fmt);
+    }
+}

--- a/cli/src/agentctl/list.rs
+++ b/cli/src/agentctl/list.rs
@@ -1,0 +1,17 @@
+use crate::commands::OutputFormat;
+use clap::Args;
+
+#[derive(Args, Debug)]
+pub struct ListArgs {
+    #[arg(help = "ID of the entity")]
+    pub id: String,
+    #[arg(short, long)]
+    pub output: Option<OutputFormat>,
+}
+
+pub fn list(args: &ListArgs) {
+    println!("Listing {}", args.id);
+    if let Some(fmt) = &args.output {
+        println!("Output format: {:?}", fmt);
+    }
+}

--- a/cli/src/agentctl/mod.rs
+++ b/cli/src/agentctl/mod.rs
@@ -1,0 +1,25 @@
+pub mod config;
+pub mod env;
+
+pub mod describe;
+pub mod deploy;
+pub mod invoke;
+pub mod list;
+
+use clap::Subcommand;
+
+#[derive(Subcommand, Debug)]
+pub enum AgentCtlCommands {
+    /// Manage configuration profiles
+    Config(config::ConfigCommands),
+    /// Manage environment profiles
+    Env(env::EnvCommands),
+    /// Describe an entity by id
+    Describe(describe::DescribeArgs),
+    /// Deploy an entity by id
+    Deploy(deploy::DeployArgs),
+    /// Invoke an entity with some input
+    Invoke(invoke::InvokeArgs),
+    /// List entities by id
+    List(list::ListArgs),
+}

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -49,3 +49,66 @@ pub fn assign_task(task_id: &str, to: &str) {
     println!("Assigning task '{}' to agent '{}'", task_id, to);
     println!("✅ Assignment complete.");
 }
+
+pub enum OutputFormat {
+    Json,
+    Toml,
+    Yaml,
+    Csv,
+}
+
+pub fn config_add(output: Option<OutputFormat>) {
+    let args = crate::agentctl::config::add::AddArgs { output };
+    crate::agentctl::config::add::add(&args);
+}
+
+pub fn config_show(output: Option<OutputFormat>) {
+    let args = crate::agentctl::config::show::ShowArgs { output };
+    crate::agentctl::config::show::show(&args);
+}
+
+pub fn env_show(output: Option<OutputFormat>) {
+    let args = crate::agentctl::env::show::ShowArgs { output };
+    crate::agentctl::env::show::show(&args);
+}
+
+pub fn env_set(profile_id: &str, output: Option<OutputFormat>) {
+    let args = crate::agentctl::env::set::SetArgs {
+        profile_id: profile_id.to_string(),
+        output,
+    };
+    crate::agentctl::env::set::set(&args);
+}
+
+pub fn describe(id: &str, output: Option<OutputFormat>) {
+    let args = crate::agentctl::describe::DescribeArgs {
+        id: id.to_string(),
+        output,
+    };
+    crate::agentctl::describe::describe(&args);
+}
+
+pub fn deploy(id: &str, output: Option<OutputFormat>) {
+    let args = crate::agentctl::deploy::DeployArgs {
+        id: id.to_string(),
+        output,
+    };
+    crate::agentctl::deploy::deploy(&args);
+}
+
+pub fn invoke(id: &str, input: &str, output: Option<OutputFormat>) {
+    let args = crate::agentctl::invoke::InvokeArgs {
+        id: id.to_string(),
+        input: input.to_string(),
+        output,
+    };
+    crate::agentctl::invoke::invoke(&args);
+}
+
+pub fn list(id: &str, output: Option<OutputFormat>) {
+    let args = crate::agentctl::list::ListArgs {
+        id: id.to_string(),
+        output,
+    };
+    crate::agentctl::list::list(&args);
+}


### PR DESCRIPTION
## Summary
- add an `agentctl` directory to organize CLI commands
- implement module scaffolding for config, env, deploy, invoke, describe and list
- update `commands.rs` to call the new stubs

## Testing
- `cargo --version`
- `cargo fmt 2>&1 | tail -n 20`

------
https://chatgpt.com/codex/tasks/task_e_688bcdb7c4a88331adef530bd590fff3