### PR TITLE
Update config command to persist settings

### DIFF
--- a/cli/spec.md
+++ b/cli/spec.md
@@ -13,6 +13,8 @@ This document outlines the specification for the CLI of the project.
 7. agentctl invoke <id> --input="<content>" 
 8. agentctl list <id>
 
+The `config` commands read and write a TOML file located at `~/.agentctl/config.toml`.
+
 
 All commands have the following flags:
 1. --output / -o json/toml/yaml/csv

--- a/cli/src/agentctl/config/add.rs
+++ b/cli/src/agentctl/config/add.rs
@@ -1,5 +1,6 @@
 use crate::commands::OutputFormat;
 use clap::Args;
+use super::file::{Config, config_path};
 
 #[derive(Args, Debug)]
 pub struct AddArgs {
@@ -8,8 +9,12 @@ pub struct AddArgs {
 }
 
 pub fn add(args: &AddArgs) {
+    let mut cfg = Config::load();
     println!("Adding configuration...");
     if let Some(fmt) = &args.output {
         println!("Output format: {:?}", fmt);
+        cfg.output_format = Some(fmt.as_str().to_string());
     }
+    cfg.save();
+    println!("Configuration written to {}", config_path().display());
 }

--- a/cli/src/agentctl/config/file.rs
+++ b/cli/src/agentctl/config/file.rs
@@ -1,0 +1,35 @@
+use serde::{Deserialize, Serialize};
+use std::{env, fs, path::PathBuf};
+
+#[derive(Serialize, Deserialize, Debug, Default)]
+pub struct Config {
+    pub output_format: Option<String>,
+}
+
+pub fn config_path() -> PathBuf {
+    env::var("HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from("."))
+        .join(".agentctl")
+        .join("config.toml")
+}
+
+impl Config {
+    pub fn load() -> Self {
+        let path = config_path();
+        if let Ok(contents) = fs::read_to_string(&path) {
+            toml::from_str(&contents).unwrap_or_default()
+        } else {
+            Config::default()
+        }
+    }
+
+    pub fn save(&self) {
+        let path = config_path();
+        if let Some(parent) = path.parent() {
+            let _ = fs::create_dir_all(parent);
+        }
+        let data = toml::to_string_pretty(self).expect("serialize config");
+        let _ = fs::write(path, data);
+    }
+}

--- a/cli/src/agentctl/config/mod.rs
+++ b/cli/src/agentctl/config/mod.rs
@@ -1,5 +1,6 @@
 pub mod add;
 pub mod show;
+pub mod file;
 
 use clap::Subcommand;
 

--- a/cli/src/agentctl/config/show.rs
+++ b/cli/src/agentctl/config/show.rs
@@ -1,5 +1,6 @@
 use crate::commands::OutputFormat;
 use clap::Args;
+use super::file::{Config, config_path};
 
 #[derive(Args, Debug)]
 pub struct ShowArgs {
@@ -8,7 +9,13 @@ pub struct ShowArgs {
 }
 
 pub fn show(args: &ShowArgs) {
-    println!("Current configuration...");
+    let cfg = Config::load();
+    println!("Current configuration at {}:", config_path().display());
+    if let Some(of) = cfg.output_format {
+        println!("output_format = {}", of);
+    } else {
+        println!("No configuration found");
+    }
     if let Some(fmt) = &args.output {
         println!("Output format: {:?}", fmt);
     }

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -57,6 +57,17 @@ pub enum OutputFormat {
     Csv,
 }
 
+impl OutputFormat {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            OutputFormat::Json => "json",
+            OutputFormat::Toml => "toml",
+            OutputFormat::Yaml => "yaml",
+            OutputFormat::Csv => "csv",
+        }
+    }
+}
+
 pub fn config_add(output: Option<OutputFormat>) {
     let args = crate::agentctl::config::add::AddArgs { output };
     crate::agentctl::config::add::add(&args);


### PR DESCRIPTION
## Summary
- keep agentctl configuration in `~/.agentctl/config.toml`
- implement loading and saving logic
- expose helper for output format string values
- document new config file behavior

## Testing
- `cargo check` *(fails: could not find `Cargo.toml`)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688beece51208331b57834c853d51e6c